### PR TITLE
add redirection frontend url after successfull social login

### DIFF
--- a/src/controllers/oauth.js
+++ b/src/controllers/oauth.js
@@ -5,7 +5,7 @@ import signAccessToken from '../helpers/jwt_helper';
 class Oauth {
   static async loginSuccess(req, res) {
     const token = await signAccessToken(req.user);
-    res.send({ message: "Login succeed", token });
+    res.redirect(`${process.env.FRONTEND_URL}/login?token=${token}`);
   }
 }
 


### PR DESCRIPTION
**What does this PR do?**

- add frontend redirect URL after google or Facebook login 
**how to test it manually**

- clone ch-redirect-frontend-url branch 
- go to /api/user/auth/google or facebook